### PR TITLE
Remove item Markdown marker (*) in some messages

### DIFF
--- a/err_stash.py
+++ b/err_stash.py
@@ -119,7 +119,7 @@ def ensure_text_matches_unique_branch(plans, branch_text):
             if not error_lines:
                 error_lines.append('More than one branch matches the text `"{}"`:'.format(branch_text))
             names = ', '.join('`{}`'.format(x['displayId']) for x in plan.branches)
-            error_lines.append("* `{slug}`: {names}".format(slug=plan.slug, names=names))
+            error_lines.append("`{slug}`: {names}".format(slug=plan.slug, names=names))
 
     if error_lines:
         error_lines.append("Use a more complete text or remove one of the branches.")
@@ -136,7 +136,7 @@ def ensure_unique_pull_requests(plans, from_branch_display_id):
             if not error_lines:
                 error_lines.append('Multiples PRs for branch `{}` found:'.format(from_branch_display_id))
             links = ['[PR#{id}]({url})'.format(id=x['id'], url=get_self_url(x)) for x in plan.pull_requests]
-            error_lines.append("* `{slug}`: {links}".format(slug=plan.slug, links=', '.join(links)))
+            error_lines.append("`{slug}`: {links}".format(slug=plan.slug, links=', '.join(links)))
     if error_lines:
         error_lines.append('Sorry you will have to sort that mess yourself. :wink:')
         raise CheckError(error_lines)
@@ -162,7 +162,7 @@ def ensure_pull_requests_target_same_branch(plans, from_branch_display_id):
             if plan.pull_requests:
                 assert len(plan.pull_requests) == 1
                 pr = plan.pull_requests[0]
-                error_lines.append('* `{slug}`: [PR#{id}]({url}) targets `{to_ref}`'.format(
+                error_lines.append('`{slug}`: [PR#{id}]({url}) targets `{to_ref}`'.format(
                                    slug=plan.slug, id=pr['id'], url=get_self_url(pr), to_ref=pr['toRef']['id']))
 
         error_lines.append('Fix those PRs and try again.')
@@ -211,7 +211,7 @@ def ensure_no_conflicts(api, from_branch, plans):
         if not pull_request.can_merge():
             if not error_lines:
                 error_lines.append('The PRs below for branch `{}` have conflicts:'.format(from_branch))
-            error_lines.append('* `{slug}`: [PR#{id}]({url}) **CONFLICTS**'.format(
+            error_lines.append('`{slug}`: [PR#{id}]({url}) **CONFLICTS**'.format(
                 slug=plan.slug, id=pr_data['id'], url=get_self_url(pr_data)))
 
     if error_lines:

--- a/tests.py
+++ b/tests.py
@@ -121,7 +121,7 @@ def test_duplicate_branches(mock_api, mocker):
 
     call_merge('ASIM-81', [
         r'More than one branch matches the text `"ASIM-81"`:',
-        r'\* `repo1`: `fb-ASIM-81-network`, `fb-ASIM-81-network-test`',
+        r'`repo1`: `fb-ASIM-81-network`, `fb-ASIM-81-network-test`',
         r'Use a more complete text.*',
     ])
 
@@ -139,7 +139,7 @@ def test_multiples_prs_for_same_branch(mock_api):
 
     call_merge('ASIM-81', [
         r'Multiples PRs for branch `fb-ASIM-81-network` found:',
-        r'\* `repo1`: \[PR#10\]\(url.com/for/10\), \[PR#12\]\(url.com/for/12\)',
+        r'`repo1`: \[PR#10\]\(url.com/for/10\), \[PR#12\]\(url.com/for/12\)',
         r'Sorry you will have to sort that mess yourself. :wink:',
     ])
 
@@ -156,8 +156,8 @@ def test_prs_with_different_targets(mock_api):
 
     call_merge('ASIM-81', [
         r'PRs in repositories for branch `fb-ASIM-81-network` have different targets:',
-        r'\* `repo1`: \[PR#10\]\(url.com/for/10\) targets `refs/heads/features`',
-        r'\* `repo3`: \[PR#17\]\(url.com/for/17\) targets `refs/heads/master`',
+        r'`repo1`: \[PR#10\]\(url.com/for/10\) targets `refs/heads/features`',
+        r'`repo3`: \[PR#17\]\(url.com/for/17\) targets `refs/heads/master`',
         r'Fix those PRs and try again.'
     ])
 
@@ -185,7 +185,7 @@ def test_merge_conflicts(mock_api):
     }
     call_merge('ASIM-81', [
         r'The PRs below for branch `fb-ASIM-81-network` have conflicts:',
-        r'\* `repo3`: \[PR#10\]\(url.com/for/10\) \*\*CONFLICTS\*\*',
+        r'`repo3`: \[PR#10\]\(url.com/for/10\) \*\*CONFLICTS\*\*',
         r'Fix the conflicts and try again. :wink:',
     ])
     assert mock_api['repo3']['pull_request']['10'].merged_version is None


### PR DESCRIPTION
RocketChat doesn't render that correctly and it ends up screwing other
markup sometimes