### PR TITLE
Remove "stash" prefix from all commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 __pycache__/
 *.pyc
 default.ini
+/plugins/
+/data/
+config.py
+errbot.log

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ Create a bot for local development:
 errbot --init
 ```
 
-And edit the generated `config.py` with your username instead of `@CHANGE_ME`.
+And edit the generated `config.py`:
 
-Start it up.
+* Change `@CHANGE_ME` to your username.
+* Change `BOT_EXTRA_PLUGIN_DIR` to point to the current directory.
+
+Start it up with:
 
 ```
 errbot -T

--- a/err_stash.py
+++ b/err_stash.py
@@ -302,6 +302,8 @@ class StashBot(BotPlugin):
         """Set or get your Stash token"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)
+        if not self.config:
+            return 'Stash plugin not configured, contact an admin.'
         if not args:
             if settings['token']:
                 return "You API Token is: `{}` (user: {})".format(settings['token'], user)

--- a/err_stash.py
+++ b/err_stash.py
@@ -292,13 +292,13 @@ class StashBot(BotPlugin):
 
 
     @botcmd
-    def stash_version(self, msg, args):
+    def version(self, msg, args):
         """Get current version and CHANGELOG"""
         return Path(__file__).parent.joinpath('CHANGELOG.md').read_text()
 
 
     @botcmd(split_args_with=None)
-    def stash_token(self, msg, args):
+    def token(self, msg, args):
         """Set or get your Stash token"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)
@@ -316,12 +316,12 @@ class StashBot(BotPlugin):
 
 
     @arg_botcmd('branch_text', help='Branch name to merge')
-    def stash_merge(self, msg, branch_text):
+    def merge(self, msg, branch_text):
         """Merges PRs related to a branch (which can be a partial match)"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)
         if not settings['token']:
-            return self.stash_token(msg, [])
+            return self.token(msg, [])
         projects = self.config['STASH_PROJECTS']
         if not projects:
             return '`STASH_PROJECTS` not configured. Use `!plugin config Stash` to configure it.'

--- a/tests.py
+++ b/tests.py
@@ -269,9 +269,16 @@ class TestBot:
             'STASH_URL': 'https://my-server.com/stash',
             'STASH_PROJECTS': ['PROJ-A', 'PROJ-B', 'PROJ-FOO'],
         }
+        return stash_plugin
 
 
-    def test_token(self, testbot):
+    def test_token(self, testbot, stash_plugin, monkeypatch):
+        monkeypatch.setattr(stash_plugin, 'config', None)
+        testbot.push_message('!stash token')
+        response = testbot.pop_message()
+        assert 'Stash plugin not configured, contact an admin.' in response
+
+        monkeypatch.undo()
         testbot.push_message('!stash token')
         response = testbot.pop_message()
         assert 'Stash API Token not configured' in response

--- a/tests.py
+++ b/tests.py
@@ -274,34 +274,34 @@ class TestBot:
 
     def test_token(self, testbot, stash_plugin, monkeypatch):
         monkeypatch.setattr(stash_plugin, 'config', None)
-        testbot.push_message('!stash token')
+        testbot.push_message('!token')
         response = testbot.pop_message()
         assert 'Stash plugin not configured, contact an admin.' in response
 
         monkeypatch.undo()
-        testbot.push_message('!stash token')
+        testbot.push_message('!token')
         response = testbot.pop_message()
         assert 'Stash API Token not configured' in response
         assert 'https://my-server.com/stash/plugins/servlet/access-tokens/manage' in response
 
-        testbot.push_message('!stash token secret-token')
+        testbot.push_message('!token secret-token')
         response = testbot.pop_message()
         assert response == 'Token saved.'
 
-        testbot.push_message('!stash token')
+        testbot.push_message('!token')
         response = testbot.pop_message()
         assert response == 'You API Token is: secret-token (user: fry)'
 
 
     def test_merge(self, testbot, mock_api):
-        testbot.push_message('!stash merge ASIM-81')
+        testbot.push_message('!merge ASIM-81')
         response = testbot.pop_message()
         assert 'Stash API Token not configured' in response
 
-        testbot.push_message('!stash token secret-token')
+        testbot.push_message('!token secret-token')
         testbot.pop_message()
 
-        testbot.push_message('!stash merge ASIM-81')
+        testbot.push_message('!merge ASIM-81')
         response = testbot.pop_message()
         assert response == (
             'Could not find any branch with text "ASIM-81" in any repositories '
@@ -310,6 +310,6 @@ class TestBot:
 
 
     def test_version(self, testbot):
-        testbot.push_message('!stash version')
+        testbot.push_message('!version')
         response = testbot.pop_message()
         assert '1.0.0' in response


### PR DESCRIPTION
Let err-bot figure out if the prefix is required based on other
plugins implementing commands with the same name