### PR TITLE
Use a prefix for the token command because it conflicts with Jenkins

### DIFF
--- a/err_stash.py
+++ b/err_stash.py
@@ -298,7 +298,7 @@ class StashBot(BotPlugin):
 
 
     @botcmd(split_args_with=None)
-    def token(self, msg, args):
+    def stash_token(self, msg, args):
         """Set or get your Stash token"""
         user = msg.frm.nick
         settings = self.load_user_settings(user)
@@ -321,7 +321,7 @@ class StashBot(BotPlugin):
         user = msg.frm.nick
         settings = self.load_user_settings(user)
         if not settings['token']:
-            return self.token(msg, [])
+            return self.stash_token(msg, [])
         projects = self.config['STASH_PROJECTS']
         if not projects:
             return '`STASH_PROJECTS` not configured. Use `!plugin config Stash` to configure it.'

--- a/tests.py
+++ b/tests.py
@@ -274,21 +274,21 @@ class TestBot:
 
     def test_token(self, testbot, stash_plugin, monkeypatch):
         monkeypatch.setattr(stash_plugin, 'config', None)
-        testbot.push_message('!token')
+        testbot.push_message('!stash token')
         response = testbot.pop_message()
         assert 'Stash plugin not configured, contact an admin.' in response
 
         monkeypatch.undo()
-        testbot.push_message('!token')
+        testbot.push_message('!stash token')
         response = testbot.pop_message()
         assert 'Stash API Token not configured' in response
         assert 'https://my-server.com/stash/plugins/servlet/access-tokens/manage' in response
 
-        testbot.push_message('!token secret-token')
+        testbot.push_message('!stash token secret-token')
         response = testbot.pop_message()
         assert response == 'Token saved.'
 
-        testbot.push_message('!token')
+        testbot.push_message('!stash token')
         response = testbot.pop_message()
         assert response == 'You API Token is: secret-token (user: fry)'
 
@@ -298,7 +298,7 @@ class TestBot:
         response = testbot.pop_message()
         assert 'Stash API Token not configured' in response
 
-        testbot.push_message('!token secret-token')
+        testbot.push_message('!stash token secret-token')
         testbot.pop_message()
 
         testbot.push_message('!merge ASIM-81')


### PR DESCRIPTION
For some reason err-bot is reloading only the last "token" command.

Add the prefix manually for now.