### PR TITLE
Modify Merge Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**1.3.0**
+
+- Modify merge message to be easier to know the target branch.
+
 **1.2.0**
 
 - Implement `--force` option to merge PRs with different target branches.

--- a/err_stash.py
+++ b/err_stash.py
@@ -262,15 +262,15 @@ def merge(url, projects, username, password, branch_text, confirm, force=False):
     plans_and_commits = get_commits_about_to_be_merged_by_pull_requests(api, plans, from_branch)
     ensure_no_conflicts(api, from_branch, [plan for (plan, _) in plans_and_commits])
 
-    yield 'Branch `{}` merged into `{}`! :white_check_mark:'.format(from_branch, ', '.join(
-        plan.to_branch for plan in plans if plan.to_branch))
+    yield 'Branch `{}` merged into:'.format(from_branch)
     shown = set()
     for plan, commits in plans_and_commits:
         pull_request = api.fetch_pull_request(plan.project, plan.slug, plan.pull_requests[0]['id'])
         if confirm:
             # https://confluence.atlassian.com/bitbucketserverkb/bitbucket-server-rest-api-for-merging-pull-request-fails-792309002.html
             pull_request.merge(version=plan.pull_requests[0]['version'])
-        yield ':white_check_mark: `{}` **{}**'.format(plan.slug, commits_text(commits))
+        yield ':white_check_mark: `{}` **{}** -> `{}`'.format(plan.slug, commits_text(commits),
+                                                              plan.to_branch.replace('refs/heads/', ''))
         shown.add(plan.slug)
     other_plans = (p for p in plans if p.slug not in shown)
     for plan in other_plans:

--- a/tests.py
+++ b/tests.py
@@ -201,7 +201,8 @@ def test_branch_commits_without_pr(mock_api):
 def test_branch_missing(mock_api):
     mock_api['PROJ-A']['repo1']['branches'] = []
     call_merge('ASIM-81', [
-        r'Branch `fb-ASIM-81-network` merged into `refs/heads/master`! :white_check_mark:',
+        r'Branch `fb-ASIM-81-network` merged into:',
+        r':white_check_mark: `repo3` **2 commits** -> `master`',
         r'Branch deleted from repositories: `repo3`',
     ])
 
@@ -221,8 +222,8 @@ def test_merge_conflicts(mock_api):
 def test_merge_success(mock_api):
     pull_request = mock_api['PROJ-B']['repo3']['pull_request']['10']
     call_merge('ASIM-81', [
-        r'Branch `fb-ASIM-81-network` merged into `refs/heads/master`! :white_check_mark:',
-        r':white_check_mark: `repo3` \*\*2 commits\*\*',
+        r'Branch `fb-ASIM-81-network` merged into:',
+        r':white_check_mark: `repo3` **2 commits** -> `master`',
         r'`repo1` - (no changes)',
         r'Branch deleted from repositories: `repo1`, `repo3`'
     ])
@@ -253,9 +254,9 @@ def test_prs_with_different_targets_force_merge(mock_api):
     }
 
     call_merge('ASIM-81', [
-        r'Branch `fb-ASIM-81-network` merged into `refs/heads/features, refs/heads/master`! :white_check_mark:',
-        r':white_check_mark: `repo1` \*\*2 commits\*\*',
-        r':white_check_mark: `repo3` \*\*2 commits\*\*',
+        r'Branch `fb-ASIM-81-network` merged into:',
+        r':white_check_mark: `repo1` **2 commits** -> `features`',
+        r':white_check_mark: `repo3` **2 commits** -> `master`',
         r'Branch deleted from repositories: `repo1`, `repo3`'
     ], force=True)
 


### PR DESCRIPTION
Modify merge message to be more friendly and easy to know which branch it was merged into.

* Modify returned message with merged branch by project
* Update Tests to expect right message