### PR TITLE
Bug Fix Bender Count All Commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**1.3.1**
+
+- Bug fix when try to merge branches and one of them does not have PR open.
+
 **1.3.0**
 
 - Modify merge message to be easier to know the target branch.

--- a/err_stash.py
+++ b/err_stash.py
@@ -188,9 +188,11 @@ def get_commits_about_to_be_merged_by_pull_requests(api, plans, from_branch):
     """Returns a summary of the commits in each PR that will be merged"""
     error_lines = []
     result = []
+    default_branch = "refs/heads/master"
     for plan in plans:
         try:
-            commits = list(api.fetch_repo_commits(plan.project, plan.slug, from_branch, plan.to_branch))
+            to_branch = plan.to_branch if plan.to_branch else default_branch
+            commits = list(api.fetch_repo_commits(plan.project, plan.slug, from_branch, to_branch))
         except stashy.errors.NotFoundException:
             commits = []
         if commits and not plan.pull_requests:
@@ -200,7 +202,7 @@ def get_commits_about_to_be_merged_by_pull_requests(api, plans, from_branch):
                                    plan.project,
                                    plan.slug,
                                    from_branch,
-                                   next(plan.to_branch for plan in plans if plan.to_branch is not None))
+                                   default_branch)
             error_lines.append('`{slug}`: **{commits_text}** ([create PR]({pr_link}))'.format(
                 slug=plan.slug, commits_text=commits_text(commits), pr_link=pr_link))
         if commits:

--- a/tests.py
+++ b/tests.py
@@ -88,8 +88,6 @@ def mock_api(mocker):
 
     def mock_fetch_repo_commits(self, project, slug, from_branch, to_branch):
         for (i_from_branch, i_to_branch), commits in projects[project][slug].get('commits', {}).items():
-            if not to_branch and commits:
-                return commits
             if from_branch in i_from_branch and to_branch in i_to_branch:
                 return commits
         response = mocker.MagicMock()
@@ -335,3 +333,5 @@ class TestBot:
         testbot.push_message('!version')
         response = testbot.pop_message()
         assert '1.0.0' in response
+
+


### PR DESCRIPTION
Bug fix for when try to merge branches and one of them does not have PR open.

* Add default_branch to never get a None to_branch in fetch_repo_commits
* Fix in test mock method which was hiding the bug