### PR TITLE
Fix broken CI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+errbot
 pytest >=3.3
 pytest-mock
 attrs


### PR DESCRIPTION
errbot dependency was removed from requirements.txt (since it shouldn't be there)

Fix the CI by defining errbot dependency on dev-requirements.txt