### PR TITLE
Fix bot initialization

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 errbot
 pytest >=3.3
+pytest-cov
 pytest-mock
 attrs
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 attrs
 stashy
 pygithub
-pytest-cov


### PR DESCRIPTION
Bot was throwing errors during initalization due pytest-cov. Since
pytest-cov is only needed for development, we are moving it from
requirements file.