### PR TITLE
Update  Bitbucket URLs to use `.co` instead of `.com.br`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Execute to configure the bot:
 
 ```
 !plugin config Stash {
-'STASH_URL': 'https://eden.esss.com.br/stash',
+'STASH_URL': 'https://eden.esss.co/stash',
 'STASH_PROJECTS': ['ESSS'],
 'GITHUB_ORGANIZATIONS': ['ESSS'],
 }

--- a/err_stash.py
+++ b/err_stash.py
@@ -733,7 +733,7 @@ class StashBot(BotPlugin):
 
     def get_configuration_template(self):
         return {
-            "STASH_URL": "https://eden.esss.com.br/stash",
+            "STASH_URL": "https://eden.esss.co/stash",
             "STASH_PROJECTS": None,
             "GITHUB_ORGANIZATIONS": None,
         }
@@ -966,7 +966,7 @@ def main(args):  # pragma: no cover
     try:
         lines = list(
             merge(
-                "https://eden.esss.com.br/stash",
+                "https://eden.esss.co/stash",
                 options.projects.split(","),
                 stash_username=options.username,
                 stash_password=options.password,

--- a/tests.py
+++ b/tests.py
@@ -746,10 +746,10 @@ def test_make_pr_link(github_api):
         == expected_pr_link
     )
 
-    expected_pr_link = fr"https://eden.esss.com.br/stash/projects/esss/repos/some_project/compare/commits?sourceBranch=dev_branch&targetBranch=master"
+    expected_pr_link = fr"https://eden.esss.co/stash/projects/esss/repos/some_project/compare/commits?sourceBranch=dev_branch&targetBranch=master"
     assert (
         make_pr_link(
-            fr"https://eden.esss.com.br/stash",
+            fr"https://eden.esss.co/stash",
             "esss",
             "some_project",
             "dev_branch",


### PR DESCRIPTION
Now that `https://eden.esss.com.br/stash` doesn't work anymore we need to update to the `.co` version.